### PR TITLE
Set the required fee

### DIFF
--- a/wsapi/wsapi.go
+++ b/wsapi/wsapi.go
@@ -1571,6 +1571,7 @@ func factoidTxToTransaction(t interfaces.ITransaction) (
 
 	if r.TotalInputs <= r.TotalOutputs+r.TotalECOutputs {
 		r.FeesPaid = 0
+		r.FeesRequired = feesRequired(t)
 	} else {
 		r.FeesPaid = r.TotalInputs - (r.TotalOutputs + r.TotalECOutputs)
 	}


### PR DESCRIPTION
This  came up in #3 as a go vet issue, since a variable was assigned to itself. This will properly set the variable to the required fee.

This potentially has side effects to anyone using this library, so I'm not sure if it should be part of the initial repo setup or a new version.